### PR TITLE
Fix Code Quality for naming variables

### DIFF
--- a/src/main/java/nightcoder/NightCoder.java
+++ b/src/main/java/nightcoder/NightCoder.java
@@ -14,17 +14,17 @@ public class NightCoder {
     private static final String DATA_FOLDER = "data";
     private static final String TASKS_FILE = "tasks.txt";
     private static Parser parser;
-    private static final Storage STORAGE = new Storage(NightCoder.DATA_FOLDER, NightCoder.TASKS_FILE);
-    private static final TaskList TASKS = new TaskList(NightCoder.STORAGE);
+    private static final Storage storage = new Storage(NightCoder.DATA_FOLDER, NightCoder.TASKS_FILE);
+    private static final TaskList tasks = new TaskList(NightCoder.storage);
 
 
     public NightCoder() {
-        NightCoder.parser = new Parser(NightCoder.STORAGE, NightCoder.TASKS);
-        NightCoder.TASKS.loadTasks();
+        NightCoder.parser = new Parser(NightCoder.storage, NightCoder.tasks);
+        NightCoder.tasks.loadTasks();
     }
 
     public void saveTasksOnClose() {
-        NightCoder.TASKS.saveTasks();
+        NightCoder.tasks.saveTasks();
     }
 
     public String getResponse(String input) {

--- a/src/main/java/nightcoder/javafx/Main.java
+++ b/src/main/java/nightcoder/javafx/Main.java
@@ -49,7 +49,7 @@ public class Main extends Application {
                 this.nightCoder.saveTasksOnClose();
             });
 
-            fxmlLoader.<MainWindow>getController().setNightCoder(this.nightCoder);  // inject the Duke instance
+            fxmlLoader.<MainWindow>getController().setNightCoder(this.nightCoder); // inject the Duke instance
             stage.show();
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/nightcoder/parser/Parser.java
+++ b/src/main/java/nightcoder/parser/Parser.java
@@ -14,8 +14,8 @@ import nightcoder.ui.Ui;
  * @version 10
  */
 public class Parser {
-    private final Storage STORAGE;
-    private final TaskList TASKS;
+    private final Storage storage;
+    private final TaskList tasks;
 
     /**
      * Constructs a {@code Parser} with the necessary dependencies.
@@ -24,8 +24,8 @@ public class Parser {
      * @param tasks   The {@code TaskList} containing the list of tasks.
      */
     public Parser(Storage storage, TaskList tasks) {
-        this.STORAGE = storage;
-        this.TASKS = tasks;
+        this.storage = storage;
+        this.tasks = tasks;
     }
 
     /**
@@ -47,7 +47,7 @@ public class Parser {
                 return Ui.getInvalidUsage("todo");
             }
             String todoParams = parts[1];
-            return this.TASKS.addToDo(todoParams);
+            return this.tasks.addToDo(todoParams);
         case "deadline":
             if (parts.length != 2) {
                 return Ui.getInvalidUsage("deadline");
@@ -65,7 +65,7 @@ public class Parser {
             // Correct Usage from here...
             String deadlineDescription = deadlineParts[0];
             String deadlineBy = deadlineParts[1];
-            return this.TASKS.addDeadline(deadlineDescription, deadlineBy);
+            return this.tasks.addDeadline(deadlineDescription, deadlineBy);
         case "event":
             if (parts.length != 2) {
                 return Ui.getInvalidUsage("event");
@@ -91,9 +91,9 @@ public class Parser {
                 return Ui.getInvalidUsage("event");
             }
             // Correct Usage from here...
-            return this.TASKS.addEvent(eventDescription, fromParams, toParams);
+            return this.tasks.addEvent(eventDescription, fromParams, toParams);
         case "list":
-            return this.TASKS.listTasks();
+            return this.tasks.listTasks();
         case "mark":
             if (parts.length != 2) {
                 return Ui.getInvalidUsage("mark");
@@ -135,7 +135,7 @@ public class Parser {
                 return Ui.getInvalidUsage("find");
             }
             String findParams = parts[1];
-            return this.TASKS.listTasks(findParams);
+            return this.tasks.listTasks(findParams);
         default:
             return """
                     [ Oops! ]
@@ -156,7 +156,7 @@ public class Parser {
      */
     private String setCompleted(int idx, boolean isCompleted) {
         // Edge-Case ['idx' out of bounds]
-        if (idx > this.TASKS.size() || idx < 1) {
+        if (idx > this.tasks.size() || idx < 1) {
             return """
                     [ Invalid Task Number! ]
                     Hmm, that number doesn't match any tasks on your list.
@@ -165,7 +165,7 @@ public class Parser {
 
         StringBuilder output = new StringBuilder();
         // idx is originally 1-indexed [Therefore minus 1 to access 0-indexed ListArray]
-        Task task = this.TASKS.get(idx - 1);
+        Task task = this.tasks.get(idx - 1);
         if (task.isCompleted() == isCompleted) {
             // Edge-Case ['task' is already set as complete/incomplete]
             if (isCompleted) {
@@ -178,7 +178,7 @@ public class Parser {
         } else {
             task.setCompleted(isCompleted);
             try {
-                this.STORAGE.setCompleted(idx - 1, isCompleted); // Convert to zero-based index
+                this.storage.setCompleted(idx - 1, isCompleted); // Convert to zero-based index
                 if (isCompleted) {
                     output.append("[ Task Marked as Complete! ]\nGreat job! Task \"").append(task.getDescription());
                     output.append("\" is now marked as done. On to the next one!");
@@ -208,7 +208,7 @@ public class Parser {
      */
     private String deleteTask(int idx) {
         // Edge-Case ['idx' out of bounds]
-        if (idx > this.TASKS.size() || idx < 1) {
+        if (idx > this.tasks.size() || idx < 1) {
             return """
                     [ Invalid Task Number! ]
                     Hmm, that number doesn't match any tasks on your list.
@@ -216,9 +216,9 @@ public class Parser {
         }
 
         // idx is originally 1-indexed [Therefore minus 1 to access 0-indexed ListArray]
-        Task task = this.TASKS.remove(idx - 1);
+        Task task = this.tasks.remove(idx - 1);
         try {
-            this.STORAGE.deleteTask(idx - 1);
+            this.storage.deleteTask(idx - 1);
         } catch (IOException e) {
             return "[ Task Deleted! ]\n" + Ui.getErrorUpdatingTasksFile(e);
         }

--- a/src/main/java/nightcoder/storage/Storage.java
+++ b/src/main/java/nightcoder/storage/Storage.java
@@ -42,7 +42,7 @@ public class Storage {
      * Reads all lines from the file and returns them as a list of Strings.
      *
      * @return An {@code ArrayList} containing all task entries from the file.
-     * Returns an empty list if the file does not exist or an error occurs.
+     *     Returns an empty list if the file does not exist or an error occurs.
      */
     public ArrayList<String> readLines() {
         File file = new File(this.DATA_FOLDER + "/" + this.TASKS_FILE);
@@ -110,6 +110,8 @@ public class Storage {
         }
         String description = parts[2];
 
+        // "Incorrect" indentation by Style Checker due to the use of "return".
+        // It should, in theory, be of the correct indentation.
         return switch (type) {
             case "T" -> new ToDo(description, isCompleted);
             case "D" -> {

--- a/src/main/java/nightcoder/task/TaskList.java
+++ b/src/main/java/nightcoder/task/TaskList.java
@@ -19,7 +19,7 @@ import nightcoder.ui.Ui;
  */
 public class TaskList {
     private ArrayList<Task> tasks;
-    private final Storage STORAGE;
+    private final Storage storage;
     private final DateTimeFormatter INPUT_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private final DateTimeFormatter OUTPUT_DATE_FORMAT = DateTimeFormatter.ofPattern("MMM dd yyyy");
 
@@ -30,7 +30,7 @@ public class TaskList {
      */
     public TaskList(Storage storage) {
         this.tasks = new ArrayList<>();
-        this.STORAGE = storage;
+        this.storage = storage;
     }
 
     /**
@@ -67,7 +67,7 @@ public class TaskList {
      * Loads tasks from the storage file and converts them into {@code ArrayList<Task>}.
      */
     public void loadTasks() {
-        this.tasks = this.STORAGE.loadTasks();
+        this.tasks = this.storage.loadTasks();
     }
 
     /**
@@ -98,7 +98,7 @@ public class TaskList {
         Task task = new ToDo(description, false);
         this.tasks.add(task);
         try {
-            this.STORAGE.appendTask("T|0|" + description);
+            this.storage.appendTask("T|0|" + description);
             return Ui.getTaskAdded(description, this.size());
         } catch (IOException e) {
             return "[ Task #" + this.size() + " Added: " + description + " ]\n" + Ui.getErrorUpdatingTasksFile(e);
@@ -119,7 +119,7 @@ public class TaskList {
         Task task = new Deadline(description, false, parsedDueBy);
         this.tasks.add(task);
         try {
-            this.STORAGE.appendTask("D|0|" + description + "|" + parsedDueBy);
+            this.storage.appendTask("D|0|" + description + "|" + parsedDueBy);
             return Ui.getTaskAdded(description, this.size());
         } catch (IOException e) {
             return "[ Task #" + this.size() + " Added: " + description + " ]\n" + Ui.getErrorUpdatingTasksFile(e);
@@ -142,7 +142,7 @@ public class TaskList {
         Task task = new Event(description, false, parsedStartTime, parsedEndTime);
         this.tasks.add(task);
         try {
-            this.STORAGE.appendTask("E|0|" + description + "|" + parsedStartTime + "|" + parsedEndTime);
+            this.storage.appendTask("E|0|" + description + "|" + parsedStartTime + "|" + parsedEndTime);
             return Ui.getTaskAdded(description, this.size());
         } catch (IOException e) {
             return "[ Task #" + this.size() + " Added: " + description + " ]\n" + Ui.getErrorUpdatingTasksFile(e);
@@ -209,7 +209,7 @@ public class TaskList {
             lines.add(task.getStringFormat());
         }
         try {
-            this.STORAGE.writeLines(lines);
+            this.storage.writeLines(lines);
         } catch (IOException e) {
             Ui.getErrorUpdatingTasksFile(e);
         }

--- a/src/main/java/nightcoder/ui/Ui.java
+++ b/src/main/java/nightcoder/ui/Ui.java
@@ -149,8 +149,8 @@ public class Ui {
         StringBuilder output = new StringBuilder("""
                 [ Night Code Command Guide ]
                 Need a hand? No problem! Here's what I can do for you:
-                
                 """);
+        output.append("\n");
 
         for (CommandHelp cmd : CommandHelp.values()) {
             output.append(cmd.getSyntax()).append("\n").append("- ").append(cmd.getDescription()).append("\n\n");

--- a/src/test/java/nightcoder/storage/StorageTest.java
+++ b/src/test/java/nightcoder/storage/StorageTest.java
@@ -10,19 +10,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StorageTest {
-    private final Storage STORAGE = new Storage("", "");
+    private final Storage storage = new Storage("", "");
 
     @Test
     public void parseStringToTask_validToDoUsage_returnsTask() {
         // Scenario 1 - Incomplete Task
         Task task1 = new ToDo("Running", false);
-        Task task1Test = this.STORAGE.parseStringToTask("T|0|Running");
+        Task task1Test = this.storage.parseStringToTask("T|0|Running");
         assertEquals(task1.getDescription(), task1Test.getDescription());
         assertEquals(task1.isCompleted(), task1Test.isCompleted());
 
         // Scenario 2 - Complete Task
         Task task2 = new ToDo("Jogging Home", true);
-        Task task2Test = this.STORAGE.parseStringToTask("T|1|Jogging Home");
+        Task task2Test = this.storage.parseStringToTask("T|1|Jogging Home");
         assertEquals(task2.getDescription(), task2Test.getDescription());
         assertEquals(task2.isCompleted(), task2Test.isCompleted());
     }
@@ -31,14 +31,14 @@ public class StorageTest {
     public void parseStringToTask_validDeadlineUsage_returnsTask() {
         // Scenario 1 - Incomplete Task
         Deadline task1 = new Deadline("Submit Report", false, "2025-02-10");
-        Task task1Test = this.STORAGE.parseStringToTask("D|0|Submit Report|2025-02-10");
+        Task task1Test = this.storage.parseStringToTask("D|0|Submit Report|2025-02-10");
         assertEquals(task1.getDescription(), task1Test.getDescription());
         assertEquals(task1.isCompleted(), task1Test.isCompleted());
         assertEquals(task1.getDueBy(), ((Deadline) task1Test).getDueBy());
 
         // Scenario 2 - Complete Task
         Deadline task2 = new Deadline("Finish Homework", true, "2025-02-15");
-        Task task2Test = this.STORAGE.parseStringToTask("D|1|Finish Homework|2025-02-15");
+        Task task2Test = this.storage.parseStringToTask("D|1|Finish Homework|2025-02-15");
         assertEquals(task2.getDescription(), task2Test.getDescription());
         assertEquals(task2.isCompleted(), task2Test.isCompleted());
         assertEquals(task2.getDueBy(), ((Deadline) task2Test).getDueBy());
@@ -48,7 +48,7 @@ public class StorageTest {
     public void parseStringToTask_validEventUsage_returnsTask() {
         // Scenario 1 - Incomplete Task
         Event task1 = new Event("Team Meeting", false, "2025-02-12 13:00", "2025-02-12 14:00");
-        Task task1Test = this.STORAGE.parseStringToTask("E|0|Team Meeting|2025-02-12 13:00|2025-02-12 14:00");
+        Task task1Test = this.storage.parseStringToTask("E|0|Team Meeting|2025-02-12 13:00|2025-02-12 14:00");
         assertEquals(task1.getDescription(), task1Test.getDescription());
         assertEquals(task1.isCompleted(), task1Test.isCompleted());
         assertEquals(task1.getStartTime(), ((Event) task1Test).getStartTime());
@@ -56,7 +56,7 @@ public class StorageTest {
 
         // Scenario 2 - Complete Task
         Event task2 = new Event("Conference", true, "2025-03-01 09:00", "2025-03-01 10:00");
-        Task task2Test = this.STORAGE.parseStringToTask("E|1|Conference|2025-03-01 09:00|2025-03-01 10:00");
+        Task task2Test = this.storage.parseStringToTask("E|1|Conference|2025-03-01 09:00|2025-03-01 10:00");
         assertEquals(task2.getDescription(), task2Test.getDescription());
         assertEquals(task2.isCompleted(), task2Test.isCompleted());
         assertEquals(task2.getStartTime(), ((Event) task2Test).getStartTime());
@@ -66,76 +66,80 @@ public class StorageTest {
     @Test
     public void parseStringToTask_invalidFormat_throwsException() {
         // Missing task type
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("|1|Todo without type"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("|1|Task without "
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("|1|Todo without type"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("|1|Task without "
                 + "type|Tonight"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("|1|Task without "
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("|1|Task without "
                 + "type|2025-01-01 10:00|2025-01-01 12:00"));
 
         // Missing completion status
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("T||Missing completion"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("D||Missing completion"
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("T||Missing completion"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("D||Missing completion"
                 + "|Tonight"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E||Missing completion"
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E||Missing completion"
                 + "|2:00|4:00"));
 
         // Missing description
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("T|0|"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("D|0||Tonight"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|0||2:00|4:00"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("T|0|"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("D|0||Tonight"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|0||2:00|4:00"));
 
         // Completely empty string
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask(""));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask(""));
 
         // Only type provided
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("T"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("D"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("T"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("D"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E"));
     }
 
     @Test
     public void parseStringToTask_invalidTaskType_throwsException() {
         // Unrecognized task type
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("X|1|Unknown Type Task"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("X|1|Unknown Type Task"));
     }
 
     @Test
     public void parseStringToTask_invalidDeadlineFormat_throwsException() {
         // Missing deadline date
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("D|0|Missing Date"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("D|0|Missing Date|"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("D|0|Missing Date"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("D|0|Missing Date|"));
 
         // Only type and status provided
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("D|1"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("D|1||"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("D|1"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("D|1||"));
     }
 
     @Test
     public void parseStringToTask_invalidEventFormat_throwsException() {
         // Missing start and/or end time
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|0|Incomplete Event"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|0|Incomplete Event|"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|0|Incomplete Event|2:00"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|0|Incomplete Event|2:00|"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|0|Incomplete Event||"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|0|Incomplete Event"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|0|Incomplete Event|"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|0|Incomplete Event|"
+                + "2:00"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|0|Incomplete Event|"
+                + "2:00|"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|0|Incomplete Event||"));
 
         // Only type and status provided
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|1"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|1|||"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|1"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|1|||"));
     }
 
     @Test
     public void parseStringToTask_invalidCompletionStatus_throwsException() {
         // Non-numeric completion status
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("T|X|Invalid Completion"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("D|X|Invalid Completion|2:00"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|X|Invalid Completion|"
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("T|X|Invalid Completion"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("D|X|Invalid Completion|"
+                + "2:00"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|X|Invalid Completion|"
                 + "2:00|4:00"));
 
         // Negative number as completion status
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("T|-1|Negative Completion"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("D|-1|Negative Completion|2:00"));
-        assertThrows(IllegalArgumentException.class, () -> STORAGE.parseStringToTask("E|-1|Negative Completion|"
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("T|-1|Negative Completion"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("D|-1|Negative Completion|"
+                + "2:00"));
+        assertThrows(IllegalArgumentException.class, () -> this.storage.parseStringToTask("E|-1|Negative Completion|"
                 + "2:00|4:00"));
     }
 }

--- a/src/test/java/nightcoder/task/TaskListTest.java
+++ b/src/test/java/nightcoder/task/TaskListTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TaskListTest {
     // Storage is instantiated but never used in the following tests
-    private final TaskList TASK_LIST = new TaskList(new Storage("", ""));
+    private final TaskList taskList = new TaskList(new Storage("", ""));
 
     @Test
     public void parseDate_all20thOfEachMonth_returnsFormattedDateString() {
@@ -19,15 +19,15 @@ public class TaskListTest {
 
         for (int month = 1; month <= 12; month++) {
             String inputDate = String.format("2025-%02d-20", month);
-            assertEquals(expectedDates[month - 1], TASK_LIST.parseDate(inputDate),
+            assertEquals(expectedDates[month - 1], this.taskList.parseDate(inputDate),
                     "Failed at month: " + month);
         }
     }
 
     @Test
     public void parseDate_invalidDate_returnsInputString() {
-        assertEquals("0000-00-00", TASK_LIST.parseDate("0000-00-00"));
-        assertEquals("2025-03-20 15:00", TASK_LIST.parseDate("2025-03-20 15:00"));
-        assertEquals("Tonight", TASK_LIST.parseDate("Tonight"));
+        assertEquals("0000-00-00", this.taskList.parseDate("0000-00-00"));
+        assertEquals("2025-03-20 15:00", this.taskList.parseDate("2025-03-20 15:00"));
+        assertEquals("Tonight", this.taskList.parseDate("Tonight"));
     }
 }


### PR DESCRIPTION
Instance level final variables have been incorrectly identified as constant variables.

Following Google's Java Style Guide, merely intending to never mutate the object is not enough to be considered a constant variable.

Let's rename instance level final variables that are not of primitive data typing using camelCase instead of SCREAMING_SNAKE_CASE.

Refer to this Google's Java Style Guide on 5.2.4 Constant names https://google.github.io/styleguide/javaguide.html